### PR TITLE
create_src.shを実行した際に、goビルドで失敗する #3

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -26,15 +26,19 @@ RUN apt-get update \
 RUN git clone https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis
 
 # https://github.com/mailhog/mhsendmail
-RUN curl -sSL https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 -o mhsendmail \
-    && chmod +x mhsendmail \
-    && mv mhsendmail /usr/local/bin/mhsendmail
+# RUN curl -sSL https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64 -o mhsendmail \
+#     && chmod +x mhsendmail \
+#     && mv mhsendmail /usr/local/bin/mhsendmail
 
 # https://github.com/axllent/mailpit/wiki/Building-from-source
-RUN git clone https://github.com/axllent/mailpit.git /mailpit \
-    && cd /mailpit \
-    && go build -ldflags "-s -w" \
-    && mv mailpit /usr/local/bin/mailpit
+# https://mailpit.axllent.org/docs/install/source/
+# https://github.com/axllent/mailpit/commit/25f8a47c73472f05b59a34605d8537884b444b65
+# Goバージョン1.20以上が必要に変更。aptでは1.19がインストールされる)
+# 16.30 /root/go/pkg/mod/modernc.org/libc@v1.43.1/pthread_musl.go:11:2: package slices is not in GOROOT (/usr/lib/go-1.19/src/slices)
+# RUN git clone https://github.com/axllent/mailpit.git /mailpit \
+#     && cd /mailpit \
+#     && go build -ldflags "-s -w" \
+#     && mv mailpit /usr/local/bin/mailpit
 
 RUN pecl install \
         memcached \

--- a/script/init/.env.local
+++ b/script/init/.env.local
@@ -64,7 +64,7 @@ MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS="info@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
-MAIL_SENDMAIL_PATH="/usr/local/bin/mailpit sendmail"
+# MAIL_SENDMAIL_PATH="/usr/local/bin/mailpit sendmail"
 
 MAIL_FROM_ADDRESS_PASSWORD_RESET="reset.password@example.com"
 MAIL_FROM_NAME_PASSWORD_RESET="パスワードリセット通知"


### PR DESCRIPTION
stand-alone sendmail binaryは無くても問題ないため、該当箇所をコメントアウト。
https://mailpit.axllent.org/docs/install/source/